### PR TITLE
Add Support for more than 1000 Photos

### DIFF
--- a/lambda/index.js
+++ b/lambda/index.js
@@ -1,4 +1,4 @@
-const { S3Client, ListObjectsV2Command } = require('@aws-sdk/client-s3');
+const { S3Client, paginateListObjectsV2 } = require('@aws-sdk/client-s3');
 
 const s3Client = new S3Client({ region: process.env.AWS_REGION });
 
@@ -16,24 +16,28 @@ exports.handler = async (event) => {
             throw new Error('BUCKET_NAME environment variable not set');
         }
 
-        // Scan bucket
-        const params = { Bucket: bucketName };
-        const data = await s3Client.send(new ListObjectsV2Command(params));
-        
-        if (!data || !Array.isArray(data.Contents)) {
-            return {
-                toDownload: [],
-                toDelete: []
-            };
+        // Scan bucket with Pagination (Handles > 1,000 files)
+        const bucketFiles = [];
+        const paginatorConfig = {
+            client: s3Client,
+            pageSize: 1000 // Requests 1,000 items at a time from S3
+        };
+
+        const paginator = paginateListObjectsV2(paginatorConfig, { Bucket: bucketName });
+
+        // Iterate through all pages provided by S3
+        for await (const page of paginator) {
+            if (page.Contents) {
+                const mappedPage = page.Contents.map(item => ({
+                    key: item.Key,
+                    lastModified: item.LastModified.toISOString(),
+                    size: item.Size,
+                    folder: item.Key.split('/')[0]
+                }));
+                bucketFiles.push(...mappedPage);
+            }
         }
 
-        // Process bucket contents
-        const bucketFiles = data.Contents.map(item => ({
-            key: item.Key,
-            lastModified: item.LastModified.toISOString(),
-            size: item.Size,
-            folder: item.Key.split('/')[0]
-        }));
         const bucketKeys = new Set(bucketFiles.map(item => item.key));
 
         // Determine changes


### PR DESCRIPTION
### Description
This PR addresses a limitation in the current synchronization logic where only the first 1,000 objects in the S3 bucket were being processed. By switching from a single `ListObjectsV2Command` to the AWS SDK v3 `paginateListObjectsV2` utility, the function now correctly handles buckets of any size.

### The Problem
The previous implementation relied on a single S3 API call. S3 limits the results of `ListObjectsV2` to a maximum of 1,000 keys per request. Source: [ListObjectsV2](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html)

### The Solution

- Integrated Paginator: Replaced the standalone command with `paginateListObjectsV2`.
- Automatic Token Handling: The logic now automatically handles ContinuationTokens to iterate through all "pages" of objects provided by S3.
- Consolidated Results: All paginated results are aggregated into a single bucketFiles array before performing the delta comparison.